### PR TITLE
When error callback is not passed, lets log it and ignore it.

### DIFF
--- a/Jablotron/jablotronClient.js
+++ b/Jablotron/jablotronClient.js
@@ -23,9 +23,7 @@ JablotronClient.prototype = {
                 self.log(response);
                 errorCallback(new Error(response['error_status']))
             }
-        }, function(error){
-            errorCallback(error);
-        });
+        }, errorCallback);
     },
 
     doRequest: function(endpoint, payload, cookies, successCallback, errorCallback) {
@@ -57,7 +55,10 @@ JablotronClient.prototype = {
           
           }).on("error", (err) => {
             this.log("Error: " + err.message);
-            errorCallback(err);
+
+            if (errorCallback != null) {
+                errorCallback(err);
+            }
           });
 
         req.write(postData);


### PR DESCRIPTION
There is only one scenario when error callback is not passed and that is the case of fetching of sessionId. Possible improvement could be adding of retry logic, but not sure if it worth it ... (in this case latency will be too high anyway and there is chance there HomeBridge will timeout it before it will finish ...)