### PR TITLE
Breaking change from Jablotron API

### DIFF
--- a/config-helper.js
+++ b/config-helper.js
@@ -16,7 +16,8 @@ JablotronConfigHelper.prototype = {
     fetchSessionId: function (callback) {
         let payload = {
             'login': this.username,
-            'password': this.password
+            'password': this.password,
+            'system': 'Android'
         };
 
         let self = this;
@@ -71,7 +72,7 @@ JablotronConfigHelper.prototype = {
         let self = this;
         this.fetchServices(function (serviceId) {
             let payload = {
-                'data': '[{"filter_data":[{"data_type":"section"},{"data_type":"keyboard"},{"data_type":"pgm"}],"service_type":"ja100","service_id":' + serviceId + ',"data_group":"serviceData","connect":true}]'
+                'data': '[{"filter_data":[{"data_type":"section"},{"data_type":"keyboard"},{"data_type":"pgm"}],"service_type":"ja100","service_id":' + serviceId + ',"data_group":"serviceData","connect":true,"system":"Android"}]'
             };
 
             self.client.doAuthenticatedRequest('/dataUpdate.json', payload, self.sessionId, function (response) {
@@ -95,7 +96,7 @@ JablotronConfigHelper.prototype = {
                     self.log("");
                 }
 
-                let keyboards = response['data']['service_data'][0]['data'][1]['data']['segments'];
+                let keyboards = response['data']['service_data'][0]['data'][2]['data']['segments'];
                 let keyboardMap = {};
                 keyboards.forEach(function (keyboard) {
                     if (self.isSegmentUsable(keyboard) && keyboard['segment_type'] == "keyboard" && keyboard['segment_subtype'] == 'section' && keyboard['segment_next_set_state'] == 'partialSet') {

--- a/lib/jablotron-client.js
+++ b/lib/jablotron-client.js
@@ -41,8 +41,7 @@ JablotronClient.prototype = {
                 'Cookie': cookiesData,
                 'x-vendor-id': 'MyJABLOTRON',
                 'Content-Type': 'application/x-www-form-urlencoded',
-                'Content-Length': postData.length,
-                'system': 'Android'
+                'Content-Length': postData.length
             }
         };
 
@@ -69,6 +68,6 @@ JablotronClient.prototype = {
         req.write(postData);
         req.end();
     }
-}
+};
 
 module.exports = JablotronClient;

--- a/lib/jablotron-client.js
+++ b/lib/jablotron-client.js
@@ -41,7 +41,8 @@ JablotronClient.prototype = {
                 'Cookie': cookiesData,
                 'x-vendor-id': 'MyJABLOTRON',
                 'Content-Type': 'application/x-www-form-urlencoded',
-                'Content-Length': postData.length
+                'Content-Length': postData.length,
+                'system': 'Android'
             }
         };
 

--- a/lib/jablotron.js
+++ b/lib/jablotron.js
@@ -19,7 +19,8 @@ Jablotron.prototype = {
 
         let payload = {
             'login': this.service.getServiceConfig().getUsername(),
-            'password': this.service.getServiceConfig().getPassword()
+            'password': this.service.getServiceConfig().getPassword(),
+            'system': 'Android'
         };
 
         let self = this;
@@ -44,7 +45,7 @@ Jablotron.prototype = {
         }
 
         let payload = {
-            'data': '[{"filter_data":[' + filterData + '],"service_type":"ja100","service_id":' + this.service.getId() + ',"data_group":"serviceData","connect":true}]'
+            'data': '[{"filter_data":[' + filterData + '],"service_type":"ja100","service_id":' + this.service.getId() + ',"data_group":"serviceData","connect":true, "system":"Android"}]'
         };
         return payload;
     },
@@ -141,6 +142,7 @@ Jablotron.prototype = {
             'segmentKey': keyboardOrSegmentKey,
             'expected_status': state,
             'control_code': this.service.getServiceConfig().getPincode(),
+            'system': 'Android'
         };
 
         this.service.log("Switching section " + accessory.getSegmentKey() + " (using " + keyboardOrSegmentKey + ") to new state: " + state);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-jablotron",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Control your Jablotron alarm system from your iOS device using HomeKit and Homebridge.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Jablotron implemented a new requirement, I fulfilled it with 'system=Android'.

Also, the keyboard_keys have been changed, the API end point we used, the nest containing the keyboards was moved 1 down. Fixed in the config-helper but you need to change the keyboard_key in order to have it working again, it will break otherwise!