### PR TITLE
Unification of names for segments.

### DIFF
--- a/config-helper.js
+++ b/config-helper.js
@@ -48,8 +48,8 @@ JablotronConfigHelper.prototype = {
     createAccessory: function (segment, keyboardKey) {
         let result = {};
         result.name = segment['segment_name'];
-        result.section_id = segment['segment_id'];
-        result.section_key = segment['segment_key'];
+        result.segment_id = segment['segment_id'];
+        result.segment_key = segment['segment_key'];
         if (keyboardKey && keyboardKey != null) {
             result.keyboard_key = keyboardKey;
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-jablotron",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Control your Jablotron alarm system from your iOS device using HomeKit and Homebridge.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Looks like forgotten renaming. When users would use the configuration utility and just copied output it didn't work. Learned that hard way ... 😊 